### PR TITLE
Fix: correctly detect Bundle Age block when Creation Timestamp is zero

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -201,7 +201,7 @@ impl Bundle {
                 ));
             }
         }
-        if self.primary.creation_timestamp.dtntime() == 0 && b_types.contains(&BUNDLE_AGE_BLOCK) {
+        if self.primary.creation_timestamp.dtntime() == 0 && !b_types.contains(&BUNDLE_AGE_BLOCK) {
             errors.push(Error::BundleError(
                 "Creation Timestamp is zero, but no Bundle Age block is present".to_string(),
             ));


### PR DESCRIPTION
The root cause of issue #6 is in the validation logic below, where an error is raised **when** the Creation Timestamp is `0` **and** a Bundle Age block *is* present, the exact opposite of the intended behavior:

```rust
if self.primary.creation_timestamp.dtntime() == 0 && b_types.contains(&BUNDLE_AGE_BLOCK) {
    errors.push(Error::BundleError(
        "Creation Timestamp is zero, but no Bundle Age block is present".to_string(),
    ));
}
```

The fix is to add the missing `!` before `b_types.contains(...)` so that the error is raised only when the Bundle Age block is **absent**.

Tested against the payload from issue #6, the bundle is now accepted as expected.

Fixes #6
