### PR TITLE
Fix: corrected wrong payload block number err msg

### DIFF
--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -335,7 +335,7 @@ impl CanonicalBlock {
                 }
                 if self.block_number != 1 {
                     return Err(Error::CanonicalBlockError(
-                        "Payload Block's block number is not zero".to_string(),
+                        "Payload Block's block number is not one".to_string(),
                     ));
                 }
             }


### PR DESCRIPTION
Fixes #8 

This PR corrects an error message in the Payload Block validation. The check requires block number to be 1, but the message incorrectly stated "not zero". It now correctly says "not one".