### PR TITLE
Update Dependencies & Migrate to Rust Edition 2024

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,11 @@ name = "bp7"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dev-dependencies]
-criterion = "0.7.0"
+# criterion enables rayon by default; rayon is incompatible with wasm32, so we disable default features
+criterion = { version = "0.7.0", default-features = false, features = [
+    "cargo_bench_support",
+    "plotters",
+] }
 test-case = "3.3.1"
 
 [[bench]]
@@ -32,7 +36,8 @@ harness = false
 [features]
 
 default = ["binary-build"]
-binary-build = []
+binary-build = ["wasm-js"]
+wasm-js = ["nanorand/getrandom"]
 bpsec = ["dep:sha2", "dep:hmac"]
 
 [dependencies]
@@ -45,18 +50,14 @@ crc = "3.3.0"
 thiserror = "2.0.16"
 bitflags = "2.9.4"
 web-time = "1.1.0"
+nanorand = "0.8.0"
 
 # bpsec dependencies
 sha2 = { version = "0.10.9", optional = true }
 hmac = { version = "0.12.1", optional = true }
 
-# non wasm config
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-nanorand = { version = "0.8.0", default-features = true }
-
-# wasm specific
-
+# wasm dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-stdweb = "0.4.20"
-nanorand = { version = "0.8.0", features = ["getrandom"] }
+wasm-bindgen = { version = "0.2.100", features = ["serde-serialize"] }
+serde-wasm-bindgen = "0.6.5"
+web-sys = { version = "0.3.77", features = ["console"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ harness = false
 [features]
 
 default = ["binary-build"]
-binary-build = ["instant"]
-benchmark-helpers = ["instant"]
+binary-build = []
 bpsec = ["dep:sha2", "dep:hmac"]
 
 [dependencies]
@@ -45,6 +44,7 @@ serde_bytes = "0.11.17"
 crc = "3.3.0"
 thiserror = "2.0.16"
 bitflags = "2.9.4"
+web-time = "1.1.0"
 
 # bpsec dependencies
 sha2 = { version = "0.10.9", optional = true }
@@ -54,11 +54,9 @@ hmac = { version = "0.12.1", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 nanorand = { version = "0.8.0", default-features = true }
-instant = { version = "0.1.13", features = ["now"], optional = true }
 
 # wasm specific
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 stdweb = "0.4.20"
 nanorand = { version = "0.8.0", features = ["getrandom"] }
-instant = { version = "0.1.13", features = ["stdweb", "now"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bp7"
-version = "0.10.7" # managed by release.sh
+version = "0.10.7"                                                               # managed by release.sh
 authors = ["Lars Baumgaertner <baumgaertner@cs.tu-darmstadt.de>"]
 edition = "2018"
 description = "Rust implementation of dtn Bundle Protocol Version 7 ([RFC 9171]"
@@ -22,8 +22,8 @@ name = "bp7"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dev-dependencies]
-criterion = "0.5.1"
-test-case = { version = "3.3.1" }
+criterion = "0.7.0"
+test-case = "3.3.1"
 
 [[bench]]
 name = "benchmark"
@@ -40,11 +40,11 @@ bpsec = ["dep:sha2", "dep:hmac"]
 humantime = "2.2.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_cbor = "0.11.2"
-serde_json = "1.0.140"
+serde_json = "1.0.143"
 serde_bytes = "0.11.17"
 crc = "3.3.0"
-thiserror = "2.0.12"
-bitflags = "2.6.0"
+thiserror = "2.0.16"
+bitflags = "2.9.4"
 
 # bpsec dependencies
 sha2 = { version = "0.10.9", optional = true }
@@ -53,12 +53,12 @@ hmac = { version = "0.12.1", optional = true }
 # non wasm config
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-nanorand = { version = "0.7.0", default-features = true }
+nanorand = { version = "0.8.0", default-features = true }
 instant = { version = "0.1.13", features = ["now"], optional = true }
 
 # wasm specific
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 stdweb = "0.4.20"
-nanorand = { version = "0.7.0", features = ["getrandom"] }
+nanorand = { version = "0.8.0", features = ["getrandom"] }
 instant = { version = "0.1.13", features = ["stdweb", "now"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bp7"
 version = "0.10.7"                                                               # managed by release.sh
 authors = ["Lars Baumgaertner <baumgaertner@cs.tu-darmstadt.de>"]
-edition = "2018"
+edition = "2021"
 description = "Rust implementation of dtn Bundle Protocol Version 7 ([RFC 9171]"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtn7/bp7-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bp7"
 version = "0.10.7"                                                               # managed by release.sh
 authors = ["Lars Baumgaertner <baumgaertner@cs.tu-darmstadt.de>"]
-edition = "2021"
+edition = "2024"
 description = "Rust implementation of dtn Bundle Protocol Version 7 ([RFC 9171]"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtn7/bp7-rs"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -5,7 +5,7 @@ use criterion::Criterion;
 use std::convert::TryFrom;
 
 use bp7::{
-    bundle, canonical, crc, dtntime, eid, flags::BlockControlFlags, primary, Bundle, ByteBuffer,
+    Bundle, ByteBuffer, bundle, canonical, crc, dtntime, eid, flags::BlockControlFlags, primary,
 };
 
 fn bench_bundle_create(crc_type: crc::CrcRawType) -> ByteBuffer {

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -24,16 +24,17 @@ fn bench_bundle_create(crc_type: crc::CrcRawType) -> ByteBuffer {
         .unwrap();
 
     let cblocks = vec![
-        canonical::new_payload_block(BlockControlFlags::empty(), b"ABC".to_vec()),
         canonical::new_bundle_age_block(
             2,                          // block number
             BlockControlFlags::empty(), // flags
             0,                          // time elapsed
         ),
+        canonical::new_payload_block(BlockControlFlags::empty(), b"ABC".to_vec()),
     ];
     let mut b = bundle::Bundle::new(pblock, cblocks);
 
     b.set_crc(crc_type);
+    b.calculate_crc();
     b.validate().unwrap();
     b.to_cbor()
 }
@@ -69,16 +70,17 @@ fn criterion_benchmark_bundle_encode(c: &mut Criterion) {
     let mut b = bundle::BundleBuilder::default()
         .primary(pblock)
         .canonicals(vec![
-            canonical::new_payload_block(BlockControlFlags::empty(), b"ABC".to_vec()),
             canonical::new_bundle_age_block(
-                1,                          // block number
+                2,                          // block number
                 BlockControlFlags::empty(), // flags
                 0,                          // time elapsed
             ),
+            canonical::new_payload_block(BlockControlFlags::empty(), b"ABC".to_vec()),
         ])
         .build()
         .unwrap();
     b.set_crc(crc::CRC_NO);
+    b.calculate_crc();
     b.validate().unwrap();
     let mut bndl = b.clone();
     c.bench_function("encode bundle no crc", move |bench| {
@@ -86,6 +88,7 @@ fn criterion_benchmark_bundle_encode(c: &mut Criterion) {
     });
 
     b.set_crc(crc::CRC_16);
+    b.calculate_crc();
     b.validate().unwrap();
     let mut bndl = b.clone();
     c.bench_function("encode bundle crc 16", move |bench| {
@@ -93,6 +96,7 @@ fn criterion_benchmark_bundle_encode(c: &mut Criterion) {
     });
 
     b.set_crc(crc::CRC_32);
+    b.calculate_crc();
     b.validate().unwrap();
     let mut bndl = b;
     c.bench_function("encode bundle crc 32", move |bench| {

--- a/examples/encoding_dump.rs
+++ b/examples/encoding_dump.rs
@@ -1,9 +1,9 @@
 use bp7::crc::CrcBlock;
 use bp7::flags::BlockControlFlags;
 use bp7::{
-    canonical, crc,
+    EndpointID, canonical, crc,
     helpers::{ser_dump, vec_dump},
-    primary, EndpointID,
+    primary,
 };
 use std::convert::TryInto;
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "bp7-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "bp7-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+libfuzzer-sys = "0.4"
 
 [dependencies.bp7]
 path = ".."

--- a/hfuzz-bp7/Cargo.toml
+++ b/hfuzz-bp7/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hfuzz-bp7"
 version = "0.1.0"
 authors = ["gh0st <1264131+gh0st42@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/hfuzz-bp7/Cargo.toml
+++ b/hfuzz-bp7/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hfuzz-bp7"
 version = "0.1.0"
 authors = ["gh0st <1264131+gh0st42@users.noreply.github.com>"]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/hfuzz-bp7/Cargo.toml
+++ b/hfuzz-bp7/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 honggfuzz = "0.5"
-bp7 = { path = ".."}
+bp7 = { path = ".." }

--- a/src/administrative_record.rs
+++ b/src/administrative_record.rs
@@ -7,7 +7,7 @@ use crate::{bundle, crc, dtn_time_now, primary};
 use core::fmt;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::{SerializeSeq, Serializer};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::dtntime::CreationTimestamp;
 use crate::dtntime::DtnTime;

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -377,13 +377,13 @@ impl Bundle {
         if let Some(pnblock) = self.extension_block_by_type_mut(PREVIOUS_NODE_BLOCK) {
             pnblock.previous_node_update(local_node);
         }
-        if let Some(bablock) = self.extension_block_by_type_mut(BUNDLE_AGE_BLOCK) {
-            if let Some(ba_orig) = bablock.bundle_age_get() {
-                bablock.bundle_age_update(ba_orig + residence_time);
-                if ba_orig + residence_time > self.primary.lifetime.as_micros() {
-                    // TODO: check lifetime exceeded calculations with rfc
-                    return false;
-                }
+        if let Some(bablock) = self.extension_block_by_type_mut(BUNDLE_AGE_BLOCK)
+            && let Some(ba_orig) = bablock.bundle_age_get()
+        {
+            bablock.bundle_age_update(ba_orig + residence_time);
+            if ba_orig + residence_time > self.primary.lifetime.as_micros() {
+                // TODO: check lifetime exceeded calculations with rfc
+                return false;
             }
         }
         !self.primary.is_lifetime_exceeded()

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -3,7 +3,7 @@ use core::convert::TryFrom;
 use core::fmt;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::{SerializeSeq, Serializer};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 use super::canonical::*;
 use super::crc::*;

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -391,10 +391,10 @@ impl CanonicalBlock {
         }
     }
     pub fn hop_count_get(&self) -> Option<(u8, u8)> {
-        if self.block_type == HOP_COUNT_BLOCK {
-            if let CanonicalData::HopCount(hc_limit, hc_count) = self.data() {
-                return Some((*hc_limit, *hc_count));
-            }
+        if self.block_type == HOP_COUNT_BLOCK
+            && let CanonicalData::HopCount(hc_limit, hc_count) = self.data()
+        {
+            return Some((*hc_limit, *hc_count));
         }
         None
     }
@@ -407,12 +407,11 @@ impl CanonicalBlock {
         false
     }
     pub fn hop_count_exceeded(&self) -> bool {
-        if self.block_type == HOP_COUNT_BLOCK {
-            if let CanonicalData::HopCount(hc_limit, hc_count) = self.data() {
-                if *hc_count > *hc_limit {
-                    return true;
-                }
-            }
+        if self.block_type == HOP_COUNT_BLOCK
+            && let CanonicalData::HopCount(hc_limit, hc_count) = self.data()
+            && *hc_count > *hc_limit
+        {
+            return true;
         }
         false
     }
@@ -424,10 +423,10 @@ impl CanonicalBlock {
         false
     }
     pub fn bundle_age_get(&self) -> Option<u128> {
-        if self.block_type == BUNDLE_AGE_BLOCK {
-            if let CanonicalData::BundleAge(age) = self.data() {
-                return Some((*age).into());
-            }
+        if self.block_type == BUNDLE_AGE_BLOCK
+            && let CanonicalData::BundleAge(age) = self.data()
+        {
+            return Some((*age).into());
         }
         None
     }
@@ -439,10 +438,10 @@ impl CanonicalBlock {
         false
     }
     pub fn previous_node_get(&self) -> Option<&EndpointID> {
-        if self.block_type == PREVIOUS_NODE_BLOCK {
-            if let CanonicalData::PreviousNode(eid) = self.data() {
-                return Some(eid);
-            }
+        if self.block_type == PREVIOUS_NODE_BLOCK
+            && let CanonicalData::PreviousNode(eid) = self.data()
+        {
+            return Some(eid);
         }
         None
     }

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -2,14 +2,14 @@ use crate::error::Error;
 use crate::error::ErrorList;
 
 use super::bundle::*;
-use super::crc::{CrcBlock, CrcRawType, CrcValue, CRC_16, CRC_32, CRC_NO};
+use super::crc::{CRC_16, CRC_32, CRC_NO, CrcBlock, CrcRawType, CrcValue};
 use super::eid::*;
 use super::flags::*;
 use core::convert::TryInto;
 use core::fmt;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::{SerializeSeq, Serializer};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use thiserror::Error;
 
 /******************************

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -8,7 +8,7 @@ use super::bundle::*;
 
 pub type CrcRawType = u8;
 
-use crc::{Crc, CRC_16_IBM_SDLC, CRC_32_ISCSI};
+use crc::{CRC_16_IBM_SDLC, CRC_32_ISCSI, Crc};
 
 pub const X25: Crc<u16> = Crc::<u16>::new(&CRC_16_IBM_SDLC);
 pub const CASTAGNOLI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
@@ -127,7 +127,7 @@ pub fn calculate_crc<T: CrcBlock + Block>(blck: &mut T) -> CrcValue {
             let crc_bak = blck.crc_value().clone(); // Backup original crc
             blck.reset_crc(); // set empty crc
             let data = blck.to_cbor(); // TODO: optimize this encoding away
-                                       // also tried crc16 crate, not a bit faster
+            // also tried crc16 crate, not a bit faster
             let chksm = X25.checksum(&data);
             let output_crc = chksm.to_be_bytes();
             blck.set_crc(crc_bak); // restore orginal crc
@@ -137,7 +137,7 @@ pub fn calculate_crc<T: CrcBlock + Block>(blck: &mut T) -> CrcValue {
             let crc_bak = blck.crc_value().clone(); // Backup original crc
             blck.reset_crc(); // set empty crc
             let data = blck.to_cbor(); // TODO: optimize this encoding away
-                                       // also tried crc32fast, was not significantly faster
+            // also tried crc32fast, was not significantly faster
             let chksm = CASTAGNOLI.checksum(&data);
             let output_crc = chksm.to_be_bytes();
             blck.set_crc(crc_bak); // restore orginal crc

--- a/src/eid.rs
+++ b/src/eid.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 use core::fmt;
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::{SerializeSeq, Serializer};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use thiserror::Error;
 
 /******************************

--- a/src/eid.rs
+++ b/src/eid.rs
@@ -176,10 +176,10 @@ impl<'de> Deserialize<'de> for EndpointID {
                         let code = 0;
                         Ok(EndpointID::DtnNone(eid_type, code))
                     } else {
-                        return Err(de::Error::invalid_value(
+                        Err(de::Error::invalid_value(
                             de::Unexpected::StructVariant,
                             &self,
-                        ));
+                        ))
                     }
                 } else if eid_type == ENDPOINT_URI_SCHEME_IPN {
                     let ipnaddr: IpnAddress = seq

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -31,14 +31,14 @@ pub struct BundleMetaData {
 
 /// A simple test for the bp7 FFI interface.
 /// On success it should always return the number 23.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn bp7_working() -> u8 {
     23
 }
 
 /// Another simple test returning a dynamic buffer with a fixed content.
 /// The returned buffer contains the following bytes: [0x42, 0x43, 0x44, 0x45]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn bp7_buffer_test() -> *mut Buffer {
     let input = vec![0x42, 0x43, 0x44, 0x45];
 
@@ -50,7 +50,7 @@ pub extern "C" fn bp7_buffer_test() -> *mut Buffer {
 }
 
 /// Generate a random bundle as a raw buffer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn helper_rnd_bundle() -> *mut Buffer {
     let mut bndl = helpers::rnd_bundle(CreationTimestamp::now());
 
@@ -67,13 +67,13 @@ pub extern "C" fn helper_rnd_bundle() -> *mut Buffer {
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn buffer_free(buf: *mut Buffer) {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn buffer_free(buf: *mut Buffer) { unsafe {
     if buf.is_null() {
         return;
     }
     drop(Box::from_raw(buf));
-}
+}}
 
 /// Try to decode a bundle from a given buffer.
 ///
@@ -83,8 +83,8 @@ pub unsafe extern "C" fn buffer_free(buf: *mut Buffer) {
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn bundle_from_cbor(ptr: *mut Buffer) -> *mut Bundle {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bundle_from_cbor(ptr: *mut Buffer) -> *mut Bundle { unsafe {
     assert!(!ptr.is_null());
     let buf = &mut *ptr;
     //println!("buf len {}", buf.len);
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn bundle_from_cbor(ptr: *mut Buffer) -> *mut Bundle {
     } else {
         std::ptr::null_mut::<Bundle>()
     }
-}
+}}
 
 /// Encode a given bundle a CBOR byte buffer
 ///
@@ -108,8 +108,8 @@ pub unsafe extern "C" fn bundle_from_cbor(ptr: *mut Buffer) -> *mut Bundle {
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn bundle_to_cbor(bndl: *mut Bundle) -> *mut Buffer {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bundle_to_cbor(bndl: *mut Bundle) -> *mut Buffer { unsafe {
     assert!(!bndl.is_null());
     let bndl = &mut *bndl;
     let mut buf = bndl.to_cbor().into_boxed_slice();
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn bundle_to_cbor(bndl: *mut Bundle) -> *mut Buffer {
     let len = buf.len() as u32;
     std::mem::forget(buf);
     Box::into_raw(Box::new(Buffer { data, len }))
-}
+}}
 
 /// Create a new bundle with standard configuration and a given payload
 ///
@@ -125,13 +125,13 @@ pub unsafe extern "C" fn bundle_to_cbor(bndl: *mut Bundle) -> *mut Buffer {
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn bundle_new_default(
     src: *const c_char,
     dst: *const c_char,
     lifetime: u64,
     ptr: *mut Buffer,
-) -> *mut Bundle {
+) -> *mut Bundle { unsafe {
     assert!(!src.is_null());
     let c_str_src = CStr::from_ptr(src);
 
@@ -167,20 +167,20 @@ pub unsafe extern "C" fn bundle_new_default(
     b.set_crc(crate::crc::CRC_NO);
     b.sort_canonicals();
     Box::into_raw(Box::new(b))
-}
+}}
 
 /// Frees the memory of a given bundle.
 /// # Safety
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn bundle_free(ptr: *mut Bundle) {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bundle_free(ptr: *mut Bundle) { unsafe {
     if ptr.is_null() {
         return;
     }
     drop(Box::from_raw(ptr));
-}
+}}
 
 /// Get the metadata from a given bundle.
 ///
@@ -188,8 +188,8 @@ pub unsafe extern "C" fn bundle_free(ptr: *mut Bundle) {
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn bundle_get_metadata(bndl: *mut Bundle) -> *mut BundleMetaData {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bundle_get_metadata(bndl: *mut Bundle) -> *mut BundleMetaData { unsafe {
     assert!(!bndl.is_null());
     let bndl = &mut *bndl;
     let timestamp = bndl.primary.creation_timestamp.dtntime();
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn bundle_get_metadata(bndl: *mut Bundle) -> *mut BundleMe
         seqno,
         lifetime,
     }))
-}
+}}
 
 /// Frees a BundleMetaData struct.
 ///
@@ -214,8 +214,8 @@ pub unsafe extern "C" fn bundle_get_metadata(bndl: *mut Bundle) -> *mut BundleMe
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn bundle_metadata_free(ptr: *mut BundleMetaData) {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bundle_metadata_free(ptr: *mut BundleMetaData) { unsafe {
     assert!(!ptr.is_null());
     let meta = &mut *ptr;
     if !meta.src.is_null() {
@@ -225,7 +225,7 @@ pub unsafe extern "C" fn bundle_metadata_free(ptr: *mut BundleMetaData) {
     if !meta.dst.is_null() {
         drop(CString::from_raw(meta.dst));
     }
-}
+}}
 
 /// Check if a given bundle is valid.
 /// This checks the primary block as well as the validity of all canonical bundles.
@@ -234,12 +234,12 @@ pub unsafe extern "C" fn bundle_metadata_free(ptr: *mut BundleMetaData) {
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn bundle_is_valid(bndl: *mut Bundle) -> bool {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bundle_is_valid(bndl: *mut Bundle) -> bool { unsafe {
     assert!(!bndl.is_null());
     let bndl = &mut *bndl;
     bndl.validate().is_ok()
-}
+}}
 
 /// Get the payload of a given bundle.
 ///
@@ -247,8 +247,8 @@ pub unsafe extern "C" fn bundle_is_valid(bndl: *mut Bundle) -> bool {
 ///
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
-#[no_mangle]
-pub unsafe extern "C" fn bundle_payload(bndl: *mut Bundle) -> *mut Buffer {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bundle_payload(bndl: *mut Bundle) -> *mut Buffer { unsafe {
     if !bndl.is_null() {
         let bndl = &mut *bndl;
         if let Some(payload) = bndl.payload() {
@@ -263,4 +263,4 @@ pub unsafe extern "C" fn bundle_payload(bndl: *mut Bundle) -> *mut Buffer {
         data: std::ptr::null_mut(),
         len: 0,
     }))
-}
+}}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,8 +5,8 @@ use std::{
 };
 
 use crate::{
-    flags::BlockControlFlags, flags::BundleControlFlags, helpers, new_payload_block, primary,
-    Bundle, CreationTimestamp, EndpointID,
+    Bundle, CreationTimestamp, EndpointID, flags::BlockControlFlags, flags::BundleControlFlags,
+    helpers, new_payload_block, primary,
 };
 
 #[repr(C)]
@@ -68,12 +68,14 @@ pub extern "C" fn helper_rnd_bundle() -> *mut Buffer {
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn buffer_free(buf: *mut Buffer) { unsafe {
-    if buf.is_null() {
-        return;
+pub unsafe extern "C" fn buffer_free(buf: *mut Buffer) {
+    unsafe {
+        if buf.is_null() {
+            return;
+        }
+        drop(Box::from_raw(buf));
     }
-    drop(Box::from_raw(buf));
-}}
+}
 
 /// Try to decode a bundle from a given buffer.
 ///
@@ -84,23 +86,25 @@ pub unsafe extern "C" fn buffer_free(buf: *mut Buffer) { unsafe {
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bundle_from_cbor(ptr: *mut Buffer) -> *mut Bundle { unsafe {
-    assert!(!ptr.is_null());
-    let buf = &mut *ptr;
-    //println!("buf len {}", buf.len);
-    assert!(!buf.data.is_null());
-    let buffer = core::slice::from_raw_parts(buf.data, buf.len as usize);
-    //println!("buffer {}", helpers::hexify(buffer));
-    let bndl: Bundle = buffer
-        .to_owned()
-        .try_into()
-        .expect("failed to load bundle from buffer");
-    if bndl.validate().is_ok() {
-        Box::into_raw(Box::new(bndl))
-    } else {
-        std::ptr::null_mut::<Bundle>()
+pub unsafe extern "C" fn bundle_from_cbor(ptr: *mut Buffer) -> *mut Bundle {
+    unsafe {
+        assert!(!ptr.is_null());
+        let buf = &mut *ptr;
+        //println!("buf len {}", buf.len);
+        assert!(!buf.data.is_null());
+        let buffer = core::slice::from_raw_parts(buf.data, buf.len as usize);
+        //println!("buffer {}", helpers::hexify(buffer));
+        let bndl: Bundle = buffer
+            .to_owned()
+            .try_into()
+            .expect("failed to load bundle from buffer");
+        if bndl.validate().is_ok() {
+            Box::into_raw(Box::new(bndl))
+        } else {
+            std::ptr::null_mut::<Bundle>()
+        }
     }
-}}
+}
 
 /// Encode a given bundle a CBOR byte buffer
 ///
@@ -109,15 +113,17 @@ pub unsafe extern "C" fn bundle_from_cbor(ptr: *mut Buffer) -> *mut Bundle { uns
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bundle_to_cbor(bndl: *mut Bundle) -> *mut Buffer { unsafe {
-    assert!(!bndl.is_null());
-    let bndl = &mut *bndl;
-    let mut buf = bndl.to_cbor().into_boxed_slice();
-    let data = buf.as_mut_ptr();
-    let len = buf.len() as u32;
-    std::mem::forget(buf);
-    Box::into_raw(Box::new(Buffer { data, len }))
-}}
+pub unsafe extern "C" fn bundle_to_cbor(bndl: *mut Bundle) -> *mut Buffer {
+    unsafe {
+        assert!(!bndl.is_null());
+        let bndl = &mut *bndl;
+        let mut buf = bndl.to_cbor().into_boxed_slice();
+        let data = buf.as_mut_ptr();
+        let len = buf.len() as u32;
+        std::mem::forget(buf);
+        Box::into_raw(Box::new(Buffer { data, len }))
+    }
+}
 
 /// Create a new bundle with standard configuration and a given payload
 ///
@@ -131,43 +137,45 @@ pub unsafe extern "C" fn bundle_new_default(
     dst: *const c_char,
     lifetime: u64,
     ptr: *mut Buffer,
-) -> *mut Bundle { unsafe {
-    assert!(!src.is_null());
-    let c_str_src = CStr::from_ptr(src);
+) -> *mut Bundle {
+    unsafe {
+        assert!(!src.is_null());
+        let c_str_src = CStr::from_ptr(src);
 
-    let r_src = c_str_src.to_str().unwrap();
-    let src_eid: EndpointID = r_src.try_into().unwrap();
+        let r_src = c_str_src.to_str().unwrap();
+        let src_eid: EndpointID = r_src.try_into().unwrap();
 
-    assert!(!dst.is_null());
-    let c_str_dst = CStr::from_ptr(dst);
-    let r_dst = c_str_dst.to_str().unwrap();
-    let dst_eid: EndpointID = r_dst.try_into().unwrap();
+        assert!(!dst.is_null());
+        let c_str_dst = CStr::from_ptr(dst);
+        let r_dst = c_str_dst.to_str().unwrap();
+        let dst_eid: EndpointID = r_dst.try_into().unwrap();
 
-    assert!(!ptr.is_null());
-    let payload = &mut *ptr;
-    assert!(!payload.data.is_null());
-    let data = core::slice::from_raw_parts(payload.data, payload.len as usize);
+        assert!(!ptr.is_null());
+        let payload = &mut *ptr;
+        assert!(!payload.data.is_null());
+        let data = core::slice::from_raw_parts(payload.data, payload.len as usize);
 
-    let pblock = primary::PrimaryBlockBuilder::default()
-        .bundle_control_flags(BundleControlFlags::BUNDLE_MUST_NOT_FRAGMENTED.bits())
-        .destination(dst_eid)
-        .source(src_eid.clone())
-        .report_to(src_eid)
-        .creation_timestamp(CreationTimestamp::now())
-        .lifetime(core::time::Duration::from_millis(lifetime))
-        .build()
-        .unwrap();
-    let mut b = Bundle::new(
-        pblock,
-        vec![new_payload_block(
-            BlockControlFlags::empty(),
-            data.to_owned(),
-        )],
-    );
-    b.set_crc(crate::crc::CRC_NO);
-    b.sort_canonicals();
-    Box::into_raw(Box::new(b))
-}}
+        let pblock = primary::PrimaryBlockBuilder::default()
+            .bundle_control_flags(BundleControlFlags::BUNDLE_MUST_NOT_FRAGMENTED.bits())
+            .destination(dst_eid)
+            .source(src_eid.clone())
+            .report_to(src_eid)
+            .creation_timestamp(CreationTimestamp::now())
+            .lifetime(core::time::Duration::from_millis(lifetime))
+            .build()
+            .unwrap();
+        let mut b = Bundle::new(
+            pblock,
+            vec![new_payload_block(
+                BlockControlFlags::empty(),
+                data.to_owned(),
+            )],
+        );
+        b.set_crc(crate::crc::CRC_NO);
+        b.sort_canonicals();
+        Box::into_raw(Box::new(b))
+    }
+}
 
 /// Frees the memory of a given bundle.
 /// # Safety
@@ -175,12 +183,14 @@ pub unsafe extern "C" fn bundle_new_default(
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bundle_free(ptr: *mut Bundle) { unsafe {
-    if ptr.is_null() {
-        return;
+pub unsafe extern "C" fn bundle_free(ptr: *mut Bundle) {
+    unsafe {
+        if ptr.is_null() {
+            return;
+        }
+        drop(Box::from_raw(ptr));
     }
-    drop(Box::from_raw(ptr));
-}}
+}
 
 /// Get the metadata from a given bundle.
 ///
@@ -189,24 +199,26 @@ pub unsafe extern "C" fn bundle_free(ptr: *mut Bundle) { unsafe {
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bundle_get_metadata(bndl: *mut Bundle) -> *mut BundleMetaData { unsafe {
-    assert!(!bndl.is_null());
-    let bndl = &mut *bndl;
-    let timestamp = bndl.primary.creation_timestamp.dtntime();
-    let seqno = bndl.primary.creation_timestamp.seqno();
-    let lifetime = bndl.primary.lifetime.as_millis() as u64;
-    let src_str = CString::new(bndl.primary.source.to_string()).unwrap();
-    let src = src_str.into_raw();
-    let dst_str = CString::new(bndl.primary.destination.to_string()).unwrap();
-    let dst = dst_str.into_raw();
-    Box::into_raw(Box::new(BundleMetaData {
-        src,
-        dst,
-        timestamp,
-        seqno,
-        lifetime,
-    }))
-}}
+pub unsafe extern "C" fn bundle_get_metadata(bndl: *mut Bundle) -> *mut BundleMetaData {
+    unsafe {
+        assert!(!bndl.is_null());
+        let bndl = &mut *bndl;
+        let timestamp = bndl.primary.creation_timestamp.dtntime();
+        let seqno = bndl.primary.creation_timestamp.seqno();
+        let lifetime = bndl.primary.lifetime.as_millis() as u64;
+        let src_str = CString::new(bndl.primary.source.to_string()).unwrap();
+        let src = src_str.into_raw();
+        let dst_str = CString::new(bndl.primary.destination.to_string()).unwrap();
+        let dst = dst_str.into_raw();
+        Box::into_raw(Box::new(BundleMetaData {
+            src,
+            dst,
+            timestamp,
+            seqno,
+            lifetime,
+        }))
+    }
+}
 
 /// Frees a BundleMetaData struct.
 ///
@@ -215,17 +227,19 @@ pub unsafe extern "C" fn bundle_get_metadata(bndl: *mut Bundle) -> *mut BundleMe
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bundle_metadata_free(ptr: *mut BundleMetaData) { unsafe {
-    assert!(!ptr.is_null());
-    let meta = &mut *ptr;
-    if !meta.src.is_null() {
-        drop(CString::from_raw(meta.src));
-    }
+pub unsafe extern "C" fn bundle_metadata_free(ptr: *mut BundleMetaData) {
+    unsafe {
+        assert!(!ptr.is_null());
+        let meta = &mut *ptr;
+        if !meta.src.is_null() {
+            drop(CString::from_raw(meta.src));
+        }
 
-    if !meta.dst.is_null() {
-        drop(CString::from_raw(meta.dst));
+        if !meta.dst.is_null() {
+            drop(CString::from_raw(meta.dst));
+        }
     }
-}}
+}
 
 /// Check if a given bundle is valid.
 /// This checks the primary block as well as the validity of all canonical bundles.
@@ -235,11 +249,13 @@ pub unsafe extern "C" fn bundle_metadata_free(ptr: *mut BundleMetaData) { unsafe
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bundle_is_valid(bndl: *mut Bundle) -> bool { unsafe {
-    assert!(!bndl.is_null());
-    let bndl = &mut *bndl;
-    bndl.validate().is_ok()
-}}
+pub unsafe extern "C" fn bundle_is_valid(bndl: *mut Bundle) -> bool {
+    unsafe {
+        assert!(!bndl.is_null());
+        let bndl = &mut *bndl;
+        bndl.validate().is_ok()
+    }
+}
 
 /// Get the payload of a given bundle.
 ///
@@ -248,19 +264,21 @@ pub unsafe extern "C" fn bundle_is_valid(bndl: *mut Bundle) -> bool { unsafe {
 /// Should only be called from FFI interface.
 /// This function can lead to UB as pointer cannot be validated!
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bundle_payload(bndl: *mut Bundle) -> *mut Buffer { unsafe {
-    if !bndl.is_null() {
-        let bndl = &mut *bndl;
-        if let Some(payload) = bndl.payload() {
-            let mut buf = payload.clone().into_boxed_slice();
-            let data = buf.as_mut_ptr();
-            let len = buf.len() as u32;
-            std::mem::forget(buf);
-            return Box::into_raw(Box::new(Buffer { data, len }));
+pub unsafe extern "C" fn bundle_payload(bndl: *mut Bundle) -> *mut Buffer {
+    unsafe {
+        if !bndl.is_null() {
+            let bndl = &mut *bndl;
+            if let Some(payload) = bndl.payload() {
+                let mut buf = payload.clone().into_boxed_slice();
+                let data = buf.as_mut_ptr();
+                let len = buf.len() as u32;
+                std::mem::forget(buf);
+                return Box::into_raw(Box::new(Buffer { data, len }));
+            }
         }
+        Box::into_raw(Box::new(Buffer {
+            data: std::ptr::null_mut(),
+            len: 0,
+        }))
     }
-    Box::into_raw(Box::new(Buffer {
-        data: std::ptr::null_mut(),
-        len: 0,
-    }))
-}}
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,11 +1,11 @@
 use crate::ByteBuffer;
-use crate::{bundle, canonical, crc, dtntime, eid, flags::BlockControlFlags, primary, Bundle};
+use crate::{Bundle, bundle, canonical, crc, dtntime, eid, flags::BlockControlFlags, primary};
 
 use core::num::ParseIntError;
 use nanorand::{Rng, WyRand};
 use std::convert::TryFrom;
 use std::fmt::Write as _;
-use std::io::{stdout, Write};
+use std::io::{Write, stdout};
 use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
 pub fn unix_timestamp() -> u64 {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -125,12 +125,12 @@ pub fn get_bench_bundle(crc_type: crc::CrcRawType) -> Bundle {
         .build()
         .unwrap();
     let cblocks = vec![
-        canonical::new_payload_block(BlockControlFlags::empty(), b"ABC".to_vec()),
         canonical::new_bundle_age_block(
             2,                          // block number
             BlockControlFlags::empty(), // flags
             0,                          // time elapsed
         ),
+        canonical::new_payload_block(BlockControlFlags::empty(), b"ABC".to_vec()),
     ];
     //let cblocks = Vec::new();
     let mut b = bundle::Bundle::new(pblock, cblocks);
@@ -141,6 +141,7 @@ pub fn get_bench_bundle(crc_type: crc::CrcRawType) -> Bundle {
     .build()
     .unwrap();*/
     b.set_crc(crc_type);
+    b.calculate_crc();
     b.validate().unwrap();
     b
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,17 +1,13 @@
-#[cfg(feature = "instant")]
 use crate::ByteBuffer;
 use crate::{bundle, canonical, crc, dtntime, eid, flags::BlockControlFlags, primary, Bundle};
 
 use core::num::ParseIntError;
 use nanorand::{Rng, WyRand};
-#[cfg(feature = "instant")]
 use std::convert::TryFrom;
 use std::fmt::Write as _;
-#[cfg(feature = "instant")]
 use std::io::{stdout, Write};
-use std::time::{SystemTime, UNIX_EPOCH}; // import without risk of name clashing
+use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
-#[cfg(not(target_arch = "wasm32"))]
 pub fn unix_timestamp() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -19,22 +15,11 @@ pub fn unix_timestamp() -> u64 {
         .as_secs()
 }
 
-#[cfg(target_arch = "wasm32")]
-pub fn unix_timestamp() -> u64 {
-    (stdweb::web::Date::now() / 1000.0) as u64
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 pub fn ts_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards!!")
         .as_millis() as u64
-}
-
-#[cfg(target_arch = "wasm32")]
-pub fn ts_ms() -> u64 {
-    (stdweb::web::Date::now()) as u64
 }
 
 /// Convert byte slice into a hex string
@@ -145,10 +130,7 @@ pub fn get_bench_bundle(crc_type: crc::CrcRawType) -> Bundle {
     b.validate().unwrap();
     b
 }
-#[cfg(feature = "instant")]
-use instant::Instant;
 
-#[cfg(feature = "instant")]
 pub fn bench_bundle_create(runs: i64, crc_type: crc::CrcRawType) -> Vec<ByteBuffer> {
     let crc_str = match crc_type {
         crc::CRC_NO => "CRC_NO",
@@ -175,7 +157,6 @@ pub fn bench_bundle_create(runs: i64, crc_type: crc::CrcRawType) -> Vec<ByteBuff
     bundles
 }
 
-#[cfg(feature = "instant")]
 pub fn bench_bundle_encode(runs: i64, crc_type: crc::CrcRawType) -> Vec<ByteBuffer> {
     let crc_str = match crc_type {
         crc::CRC_NO => "CRC_NO",
@@ -205,7 +186,6 @@ pub fn bench_bundle_encode(runs: i64, crc_type: crc::CrcRawType) -> Vec<ByteBuff
     bundles
 }
 
-#[cfg(feature = "instant")]
 pub fn bench_bundle_load(runs: i64, crc_type: crc::CrcRawType, mut bundles: Vec<ByteBuffer>) {
     let crc_str = match crc_type {
         crc::CRC_NO => "CRC_NO",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub mod wasm;
 
 pub use bundle::{Bundle, ByteBuffer};
 pub use canonical::*;
-pub use dtntime::{dtn_time_now, CreationTimestamp, DtnTime};
+pub use dtntime::{CreationTimestamp, DtnTime, dtn_time_now};
 pub use eid::EndpointID;
 pub use helpers::hexify;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,13 @@ use std::io::prelude::*;
 
 fn usage(filepath: &str) {
     println!("usage {:?} <cmd> [args]", filepath);
-    println!("\t encode <manifest> <payloadfile | - > [-x] - encode bundle and output raw bytes or hex string (-x)");
+    println!(
+        "\t encode <manifest> <payloadfile | - > [-x] - encode bundle and output raw bytes or hex string (-x)"
+    );
     println!("\t decode <hexstring | - > [-p] - decode bundle or payload only (-p)");
-    println!("\t dtntime [dtntimestamp] - prints current time as dtntimestamp or prints dtntime human readable");
+    println!(
+        "\t dtntime [dtntimestamp] - prints current time as dtntimestamp or prints dtntime human readable"
+    );
     println!("\t d2u [dtntimestamp] - converts dtntime to unixstimestamp");
     println!("\t rnd [-r] - return a random bundle either hexencoded or raw bytes (-r)");
     println!("\t benchmark - run a simple benchmark encoding/decoding bundles");

--- a/src/primary.rs
+++ b/src/primary.rs
@@ -10,7 +10,7 @@ use core::fmt;
 use core::{convert::TryFrom, time::Duration};
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::{SerializeSeq, Serializer};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use thiserror::Error;
 
 /******************************

--- a/src/security.rs
+++ b/src/security.rs
@@ -24,7 +24,7 @@ use sha2::{Sha256, Sha384, Sha512};
 
 use serde::de::{SeqAccess, Visitor};
 use serde::ser::{SerializeSeq, Serializer};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 // https://www.rfc-editor.org/rfc/rfc9172.html#BlockType
 pub const INTEGRITY_BLOCK: CanonicalBlockType = 11;
@@ -554,7 +554,9 @@ impl IntegrityBlock {
 
                 self.security_results.push(vec![(ippt.0, result_value)]);
             } else {
-                eprint!("Security Target and Ippt mismatch. Make sure there is an ippt for each target.")
+                eprint!(
+                    "Security Target and Ippt mismatch. Make sure there is an ippt for each target."
+                )
             }
         }
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,101 +1,159 @@
+use wasm_bindgen::prelude::*;
+
 use crate::bundle::Bundle;
-use crate::dtntime::{CreationTimestamp, DtnTimeHelpers};
+use crate::dtntime::CreationTimestamp;
 use crate::eid::*;
 use core::convert::TryFrom;
-use stdweb::*;
 
-js_serializable!(Bundle);
-js_deserializable!(Bundle);
+/// Create a new standard bundle with current timestamp
+#[wasm_bindgen]
+pub fn new_std_bundle_now(src: &str, dst: &str, payload: &str) -> Result<JsValue, JsValue> {
+    let src_eid = EndpointID::try_from(src.to_string())
+        .map_err(|e| JsValue::from_str(&format!("Invalid source address: {}", e)))?;
+    let dst_eid = EndpointID::try_from(dst.to_string())
+        .map_err(|e| JsValue::from_str(&format!("Invalid destination address: {}", e)))?;
 
-#[js_export]
-fn new_std_bundle_now(src: String, dst: String, payload: String) -> Bundle {
-    crate::bundle::new_std_payload_bundle(
-        EndpointID::try_from(src).expect("invalid src address"),
-        EndpointID::try_from(dst).expect("invalid dst address"),
-        payload.into(),
-    )
+    let bundle =
+        crate::bundle::new_std_payload_bundle(src_eid, dst_eid, payload.as_bytes().to_vec());
+
+    serde_wasm_bindgen::to_value(&bundle)
+        .map_err(|e| JsValue::from_str(&format!("Serialization error: {}", e)))
 }
 
-#[js_export]
-fn rnd_bundle_now() -> Bundle {
-    crate::helpers::rnd_bundle(CreationTimestamp::now())
+/// Create a random bundle with current timestamp
+#[wasm_bindgen]
+pub fn rnd_bundle_now() -> Result<JsValue, JsValue> {
+    let bundle = crate::helpers::rnd_bundle(CreationTimestamp::now());
+    serde_wasm_bindgen::to_value(&bundle)
+        .map_err(|e| JsValue::from_str(&format!("Serialization error: {}", e)))
 }
 
-#[js_export]
-fn encode_to_cbor(b: Bundle) -> crate::ByteBuffer {
-    b.clone().to_cbor()
+/// Encode a bundle to CBOR bytes
+#[wasm_bindgen]
+pub fn encode_to_cbor(bundle_js: &JsValue) -> Result<Vec<u8>, JsValue> {
+    let mut bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(bundle.to_cbor())
 }
 
-#[js_export]
-fn decode_from_cbor(buf: crate::ByteBuffer) -> Bundle {
-    // TODO: correct error handling for javascript
-    Bundle::try_from(buf).expect("error decoding bundle")
-}
-#[js_export]
-fn bid_from_bundle(b: Bundle) -> String {
-    b.id()
-}
-
-#[js_export]
-fn bid_from_cbor(buf: crate::ByteBuffer) -> String {
-    bid_from_bundle(decode_from_cbor(buf))
-}
-#[js_export]
-fn payload_from_bundle(b: Bundle) -> Option<crate::ByteBuffer> {
-    b.payload().map(|d| d.clone())
+/// Decode a bundle from CBOR bytes
+#[wasm_bindgen]
+pub fn decode_from_cbor(buf: &[u8]) -> Result<JsValue, JsValue> {
+    let bundle = Bundle::try_from(buf.to_vec())
+        .map_err(|e| JsValue::from_str(&format!("CBOR decode error: {}", e)))?;
+    serde_wasm_bindgen::to_value(&bundle)
+        .map_err(|e| JsValue::from_str(&format!("Serialization error: {}", e)))
 }
 
-#[js_export]
-fn payload_from_cbor(buf: crate::ByteBuffer) -> Option<crate::ByteBuffer> {
-    payload_from_bundle(decode_from_cbor(buf))
+/// Get bundle ID from a bundle object
+#[wasm_bindgen]
+pub fn bid_from_bundle(bundle_js: &JsValue) -> Result<String, JsValue> {
+    let bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(bundle.id())
 }
 
-#[js_export]
-fn valid_bundle(b: Bundle) -> bool {
-    !b.primary.is_lifetime_exceeded() && b.validate().is_ok()
+/// Get bundle ID from CBOR bytes
+#[wasm_bindgen]
+pub fn bid_from_cbor(buf: &[u8]) -> Result<String, JsValue> {
+    let bundle = Bundle::try_from(buf.to_vec())
+        .map_err(|e| JsValue::from_str(&format!("CBOR decode error: {}", e)))?;
+    Ok(bundle.id())
 }
 
-#[js_export]
-fn valid_cbor(buf: crate::ByteBuffer) -> bool {
-    valid_bundle(decode_from_cbor(buf))
+/// Get sender from a bundle object
+#[wasm_bindgen]
+pub fn sender_from_bundle(bundle_js: &JsValue) -> Result<String, JsValue> {
+    let bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(bundle.primary.source.to_string())
 }
 
-#[js_export]
-fn sender_from_bundle(b: Bundle) -> String {
-    b.primary.source.to_string()
+/// Get sender from CBOR bytes
+#[wasm_bindgen]
+pub fn sender_from_cbor(buf: &[u8]) -> Result<String, JsValue> {
+    let bundle = Bundle::try_from(buf.to_vec())
+        .map_err(|e| JsValue::from_str(&format!("CBOR decode error: {}", e)))?;
+    Ok(bundle.primary.source.to_string())
 }
 
-#[js_export]
-fn sender_from_cbor(buf: crate::ByteBuffer) -> String {
-    sender_from_bundle(decode_from_cbor(buf))
+/// Get recipient from a bundle object
+#[wasm_bindgen]
+pub fn recipient_from_bundle(bundle_js: &JsValue) -> Result<String, JsValue> {
+    let bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(bundle.primary.destination.to_string())
 }
 
-#[js_export]
-fn recipient_from_bundle(b: Bundle) -> String {
-    b.primary.destination.to_string()
+/// Get recipient from CBOR bytes
+#[wasm_bindgen]
+pub fn recipient_from_cbor(buf: &[u8]) -> Result<String, JsValue> {
+    let bundle = Bundle::try_from(buf.to_vec())
+        .map_err(|e| JsValue::from_str(&format!("CBOR decode error: {}", e)))?;
+    Ok(bundle.primary.destination.to_string())
 }
 
-#[js_export]
-fn recipient_from_cbor(buf: crate::ByteBuffer) -> String {
-    recipient_from_bundle(decode_from_cbor(buf))
+/// Get timestamp from a bundle object
+#[wasm_bindgen]
+pub fn timestamp_from_bundle(bundle_js: &JsValue) -> Result<String, JsValue> {
+    let bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(bundle.primary.creation_timestamp.to_string())
 }
 
-#[js_export]
-fn timestamp_from_bundle(b: Bundle) -> String {
-    b.primary.creation_timestamp.to_owned().to_string()
+/// Get timestamp from CBOR bytes
+#[wasm_bindgen]
+pub fn timestamp_from_cbor(buf: &[u8]) -> Result<String, JsValue> {
+    let bundle = Bundle::try_from(buf.to_vec())
+        .map_err(|e| JsValue::from_str(&format!("CBOR decode error: {}", e)))?;
+    Ok(bundle.primary.creation_timestamp.to_string())
 }
 
-#[js_export]
-fn timestamp_from_cbor(buf: crate::ByteBuffer) -> String {
-    timestamp_from_bundle(decode_from_cbor(buf))
+/// Extract payload from a bundle object
+#[wasm_bindgen]
+pub fn payload_from_bundle(bundle_js: &JsValue) -> Result<Option<Vec<u8>>, JsValue> {
+    let bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(bundle.payload().cloned())
 }
 
-#[js_export]
-fn bundle_is_administrative_record(b: Bundle) -> bool {
-    b.is_administrative_record()
+/// Extract payload from CBOR bytes
+#[wasm_bindgen]
+pub fn payload_from_cbor(buf: &[u8]) -> Result<Option<Vec<u8>>, JsValue> {
+    let bundle = Bundle::try_from(buf.to_vec())
+        .map_err(|e| JsValue::from_str(&format!("CBOR decode error: {}", e)))?;
+    Ok(bundle.payload().cloned())
 }
 
-#[js_export]
-fn cbor_is_administrative_record(buf: crate::ByteBuffer) -> bool {
-    bundle_is_administrative_record(decode_from_cbor(buf))
+/// Validate a bundle object
+#[wasm_bindgen]
+pub fn valid_bundle(bundle_js: &JsValue) -> Result<bool, JsValue> {
+    let bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(!bundle.primary.is_lifetime_exceeded() && bundle.validate().is_ok())
+}
+
+/// Validate CBOR bytes as a bundle
+#[wasm_bindgen]
+pub fn valid_cbor(buf: &[u8]) -> Result<bool, JsValue> {
+    match Bundle::try_from(buf.to_vec()) {
+        Ok(bundle) => Ok(!bundle.primary.is_lifetime_exceeded() && bundle.validate().is_ok()),
+        Err(_) => Ok(false),
+    }
+}
+
+/// Check if bundle is an administrative record
+#[wasm_bindgen]
+pub fn bundle_is_administrative_record(bundle_js: &JsValue) -> Result<bool, JsValue> {
+    let bundle: Bundle = serde_wasm_bindgen::from_value(bundle_js.clone())
+        .map_err(|e| JsValue::from_str(&format!("Deserialization error: {}", e)))?;
+    Ok(bundle.is_administrative_record())
+}
+
+/// Check if CBOR bytes represent an administrative record bundle
+#[wasm_bindgen]
+pub fn cbor_is_administrative_record(buf: &[u8]) -> Result<bool, JsValue> {
+    let bundle = Bundle::try_from(buf.to_vec())
+        .map_err(|e| JsValue::from_str(&format!("CBOR decode error: {}", e)))?;
+    Ok(bundle.is_administrative_record())
 }


### PR DESCRIPTION
This PR modernizes the project by updating dependencies, and making the necessary code changes throughout the codebase. It also upgrades the Rust edition to 2024.

This time, larger dependency migrations are split into individual commits. This PR does not (yet) include the migration away from `serde_cbor`; more on that later. First, the other changes:

- Fixed the benchmarking code for native targets. The payload block position was incorrect and the CRC was not calculated.
- Replaced `instant` with `web-time` because [`instant` is unmaintained](https://osv.dev/vulnerability/RUSTSEC-2024-0384). On native platforms `web-time` re-exports `std::time`, which let me remove a fair amount of target-specific code.
- Migrated away from `stdweb`.
  - I rewrote the `print` macros in `examples/benchmark.rs` using `web-sys` and migrated `wasm.rs` to `wasm-bindgen` and `serde-wasm-bindgen`.
  - I also had to diable the default feature `rayon` of `criterion` since it doesn't compile on `wasm32-*` targets. Besides `cargo bench` no longer running in parallel, this shouldn't cause any issues.
  - I also adjusted the `nanorand`/`getrandom` setup. The `getrandom` `wasm_js` backend is now behind the feature `wasm-js`, which is activated by default. This allows it to be deactivated, as suggested by [the docs](https://docs.rs/getrandom/latest/getrandom/#webassembly-support).
  - Finally, I reworked the WASM section in `README.md` for new instructions on using `bp7-rs` with WASM.

Before and after making all these changes, I made sure that `cargo fmt` and `cargo clippy` are happy.


About CBOR:
I prepared branches, each with a single additional commit for the migration: [`ciborium`](https://github.com/LeWimbes/bp7-rs/tree/ciborium) and [`minicbor`](https://github.com/LeWimbes/bp7-rs/tree/minicbor). Below are the `cargo bench` outputs for all three branches. I always ran `cargo bench` on `serde_cbor` first, then on `ciborium` or `minicbor`, to keep reported changes somewhat comparable.

In short, `minicbor` is much faster than `ciborium` but slightly slower than `serde_cbor`. My [earlier benchmarks](https://github.com/dtn7/dtn7-rs/pull/77#issuecomment-3250326138) likely didn’t show this because they focused on large binary blobs; the current differences seem to come from per-(de)serialization or per-field overhead.

As mentioned in an [earlier comment](https://github.com/dtn7/dtn7-rs/pull/77#issuecomment-3249918431), the migration to `ciborium` was pretty straightforward. 

By contrast, migrating to `minicbor` was slightly more complicated:
- For deserializating EIDs, I had to introduce an untagged enum to handle both representations.
- Also, I needed to avoid relying on `size_hint()`. Apparently, `minicbor` heavily relies on [indefinite-length arrays](https://datatracker.ietf.org/doc/html/rfc8949#name-indefinite-lengths-for-some). This causes `size_hint()` to return `None`, resulting in a failure to deserialize. Using `next_element()` works more reliably.

`serde_cbor`:
```
     Running benches/benchmark.rs (target/release/deps/benchmark-f830f27c5341a159)
Gnuplot not found, using plotters backend
create bundle no crc    time:   [736.62 ns 737.64 ns 739.01 ns]
                        change: [−0.3170% −0.0003% +0.2991%] (p = 1.00 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

create bundle crc 16    time:   [2.5892 µs 2.5927 µs 2.5969 µs]
                        change: [−1.3257% −0.8116% −0.4317%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

create bundle crc 32    time:   [2.6141 µs 2.6174 µs 2.6211 µs]
                        change: [−0.2873% −0.1147% +0.0678%] (p = 0.22 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

encode bundle no crc    time:   [325.24 ns 326.01 ns 326.93 ns]
                        change: [+0.2112% +0.6521% +1.1128%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

encode bundle crc 16    time:   [926.13 ns 927.41 ns 928.92 ns]
                        change: [+2.5870% +2.8796% +3.2110%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

encode bundle crc 32    time:   [939.04 ns 940.69 ns 942.60 ns]
                        change: [+4.0007% +4.2797% +4.5639%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

decode bundle no crc    time:   [622.20 ns 623.57 ns 625.14 ns]
                        change: [−0.0976% +0.1264% +0.3357%] (p = 0.25 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

decode bundle crc 16    time:   [1.4783 µs 1.4806 µs 1.4837 µs]
                        change: [−0.7633% −0.5830% −0.3879%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

decode bundle crc 32    time:   [1.4913 µs 1.4961 µs 1.5012 µs]
                        change: [−0.6456% −0.2457% +0.1850%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```


`ciborium`:
```
     Running benches/benchmark.rs (target/release/deps/benchmark-b3204db99ffc90f8)
Gnuplot not found, using plotters backend
create bundle no crc    time:   [948.35 ns 949.90 ns 951.84 ns]
                        change: [+28.345% +28.670% +28.965%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

create bundle crc 16    time:   [3.5623 µs 3.5696 µs 3.5803 µs]
                        change: [+37.401% +38.044% +39.215%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

create bundle crc 32    time:   [3.5675 µs 3.5763 µs 3.5876 µs]
                        change: [+36.162% +36.495% +36.865%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe

encode bundle no crc    time:   [540.92 ns 542.41 ns 544.08 ns]
                        change: [+64.438% +65.138% +65.811%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

encode bundle crc 16    time:   [1.4330 µs 1.4349 µs 1.4373 µs]
                        change: [+54.253% +54.776% +55.199%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

encode bundle crc 32    time:   [1.4272 µs 1.4289 µs 1.4307 µs]
                        change: [+51.121% +51.511% +51.872%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

decode bundle no crc    time:   [2.2373 µs 2.2435 µs 2.2505 µs]
                        change: [+257.96% +258.77% +259.66%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

decode bundle crc 16    time:   [3.5308 µs 3.5346 µs 3.5383 µs]
                        change: [+138.23% +138.62% +138.98%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

decode bundle crc 32    time:   [3.5356 µs 3.5419 µs 3.5504 µs]
                        change: [+135.79% +136.79% +137.63%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
```

`minicbor`:
```
     Running benches/benchmark.rs (target/release/deps/benchmark-ca21f73e4612a607)
Gnuplot not found, using plotters backend
create bundle no crc    time:   [734.02 ns 735.53 ns 737.11 ns]
                        change: [−2.0451% −1.7979% −1.5387%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

create bundle crc 16    time:   [2.7177 µs 2.7206 µs 2.7241 µs]
                        change: [+4.1521% +4.3702% +4.6286%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

create bundle crc 32    time:   [2.7142 µs 2.7190 µs 2.7245 µs]
                        change: [+2.2591% +2.4829% +2.7390%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

encode bundle no crc    time:   [318.52 ns 318.98 ns 319.46 ns]
                        change: [−4.0902% −3.8811% −3.6781%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

encode bundle crc 16    time:   [966.93 ns 967.94 ns 968.92 ns]
                        change: [+1.7043% +2.0822% +2.4456%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

encode bundle crc 32    time:   [970.62 ns 972.04 ns 973.74 ns]
                        change: [+4.1861% +4.4392% +4.7628%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

decode bundle no crc    time:   [723.98 ns 725.77 ns 727.61 ns]
                        change: [+15.145% +15.440% +15.719%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild

decode bundle crc 16    time:   [1.5777 µs 1.5802 µs 1.5826 µs]
                        change: [+6.7964% +7.0721% +7.3871%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high severe

decode bundle crc 32    time:   [1.5833 µs 1.5868 µs 1.5902 µs]
                        change: [+7.8039% +8.0782% +8.4166%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
```
